### PR TITLE
Strip the initial + from a subreading lemma.

### DIFF
--- a/streamparser.py
+++ b/streamparser.py
@@ -55,7 +55,7 @@ class LexicalUnit:
 
                 subreadingParts = re.findall(r'([^<]+)((?:<[^>]+>)+)', reading)
                 for subreading in subreadingParts:
-                    baseform = subreading[0]
+                    baseform = subreading[0].lstrip('+')
                     tags = set(re.findall(r'<([^>]+)>', subreading[1]))
 
                     subreadings.append(Reading(baseform=baseform, tags=tags))


### PR DESCRIPTION
Any actual + would be escaped, so this Should Be Safe™
