### PR TITLE
Add py.typed

### DIFF
--- a/MANIFEST.in
+++ b/MANIFEST.in
@@ -1,2 +1,3 @@
-include README.md
 include LICENSE
+include py.typed
+include README.md

--- a/setup.py
+++ b/setup.py
@@ -32,5 +32,8 @@ setup(
     entry_points={
         'console_scripts': ['apertium-streamparser=streamparser:main'],
     },
+    package_data={
+        'streamparser': ['py.typed'],
+    },
     py_modules=['streamparser'],
 )

--- a/streamparser.py
+++ b/streamparser.py
@@ -15,7 +15,7 @@ __copyright__ = 'Copyright 2016--2018, Sushain K. Cherivirala, Kevin Brubeck Unh
 __credits__ = ['Sushain K. Cherivirala', 'Kevin Brubeck Unhammer']
 __license__ = 'GPLv3+'
 __status__ = 'Production'
-__version__ = '5.0.2'
+__version__ = '5.0.3'
 
 import fileinput
 import functools


### PR DESCRIPTION
This doesn't seem to actually work as it should, unfortunately... Maybe the `setup.py` is incorrect in some way and preventing the `py.typed` from being picked up or there's an incompatibility with `py_modules.`