### PR TITLE
Parsing wordbound blanks with the lexical unit

### DIFF
--- a/streamparser.py
+++ b/streamparser.py
@@ -162,7 +162,7 @@ class LexicalUnit:
 
         if("]]^" in cohort[0]):
             split_form = cohort[0].split("]]^")
-            self.wordbound_blank = split_form[0]
+            self.wordbound_blank = split_form[0] + "]]"
             self.wordform = split_form[1]
         else:
             self.wordform = cohort[0]
@@ -238,6 +238,7 @@ def parse(stream, with_text=False):  # type: (Iterator[str], bool) -> Iterator[U
             if char == '[':
                 next_char = next(stream)
                 if next_char == '[':
+                    buffer += "[[";
                     in_lexical_unit = True
                 else:
                     in_superblank = True

--- a/streamparser.py
+++ b/streamparser.py
@@ -164,7 +164,7 @@ class LexicalUnit:
             self.wordbound_blank, self.wordform = cohort[0].split(']]^', 1)
             self.wordbound_blank += ']]'
         else:
-            self.wordbound_blank = ''
+            self.wordbound_blank = None
             self.wordform = cohort[0]
 
         readings = cohort[1:]

--- a/streamparser.py
+++ b/streamparser.py
@@ -246,7 +246,7 @@ def parse(stream, with_text=False):  # type: (Iterator[str], bool) -> Iterator[U
                     if next_char == ']':
                         in_superblank = False
                         text_buffer += next_char
-                    elif char == '\\':
+                    elif next_char == '\\':
                         text_buffer += next_char
                         text_buffer += next(stream)
                     else:

--- a/streamparser.py
+++ b/streamparser.py
@@ -164,7 +164,7 @@ class LexicalUnit:
             self.wordbound_blank, self.wordform = cohort[0].split(']]^', 1)
             self.wordbound_blank += ']]'
         else:
-            self.wordbound_blank = None
+            self.wordbound_blank = ''
             self.wordform = cohort[0]
 
         readings = cohort[1:]

--- a/streamparser.py
+++ b/streamparser.py
@@ -165,6 +165,7 @@ class LexicalUnit:
             self.wordbound_blank = split_form[0] + "]]"
             self.wordform = split_form[1]
         else:
+            self.wordbound_blank = ""
             self.wordform = cohort[0]
 
         readings = cohort[1:]

--- a/streamparser.py
+++ b/streamparser.py
@@ -160,12 +160,11 @@ class LexicalUnit:
 
         cohort = re.split(r'(?<!\\)/', lexical_unit)
 
-        if "]]^" in cohort[0]:
-            split_form = cohort[0].split("]]^")
-            self.wordbound_blank = split_form[0] + "]]"
-            self.wordform = split_form[1]
+        if ']]^' in cohort[0]:
+            self.wordbound_blank, self.wordform = cohort[0].split(']]^', 1)
+            self.wordbound_blank += ']]'
         else:
-            self.wordbound_blank = ""
+            self.wordbound_blank = ''
             self.wordform = cohort[0]
 
         readings = cohort[1:]
@@ -239,7 +238,7 @@ def parse(stream, with_text=False):  # type: (Iterator[str], bool) -> Iterator[U
             if char == '[':
                 next_char = next(stream)
                 if next_char == '[':
-                    buffer += "[[";
+                    buffer += '[['
                     in_lexical_unit = True
                 else:
                     in_superblank = True
@@ -252,7 +251,7 @@ def parse(stream, with_text=False):  # type: (Iterator[str], bool) -> Iterator[U
                         text_buffer += next(stream)
                     else:
                         text_buffer += next_char
-                
+
             elif char == '^':
                 in_lexical_unit = True
             elif char == '\\':
@@ -289,4 +288,3 @@ def main():  # type: () -> None
 
 if __name__ == '__main__':
     main()
-

--- a/streamparser.py
+++ b/streamparser.py
@@ -160,7 +160,7 @@ class LexicalUnit:
 
         cohort = re.split(r'(?<!\\)/', lexical_unit)
 
-        if("]]^" in cohort[0]):
+        if "]]^" in cohort[0]:
             split_form = cohort[0].split("]]^")
             self.wordbound_blank = split_form[0] + "]]"
             self.wordform = split_form[1]
@@ -289,5 +289,4 @@ def main():  # type: () -> None
 
 if __name__ == '__main__':
     main()
-
 

--- a/test.py
+++ b/test.py
@@ -107,7 +107,7 @@ class Test(unittest.TestCase):
             self.assertEqual(len(caught_warnings), 1)
             self.assertTrue(issubclass(caught_warnings[0].category, RuntimeWarning))
             self.assertIn('Empty readings', str(caught_warnings[0].message))
-            
+
     def test_wordbound_blanks(self):
         lexical_units = list(parse(self.s5))
         self.assertEqual(len(lexical_units), 3)
@@ -116,16 +116,16 @@ class Test(unittest.TestCase):
             [
                 [SReading(baseform='name', tags=['n', 'sg'])],
                 [SReading(baseform='name', tags=['vblex', 'inf'])],
-                [SReading(baseform='name', tags=['vblex', 'pres'])]
-            ]
+                [SReading(baseform='name', tags=['vblex', 'pres'])],
+            ],
         )
-        self.assertEqual(lexical_units[0].wordform, "My")
-        self.assertEqual(lexical_units[0].wordbound_blank, "[[t:b:123456]]")
-        self.assertEqual(lexical_units[1].wordform, "test")
-        self.assertEqual(lexical_units[1].wordbound_blank, "")
-        self.assertEqual(lexical_units[2].wordform, "name")
-        self.assertEqual(lexical_units[2].wordbound_blank, "[[t:i:12asda; t:p:1abc76]]")
-        
+        self.assertEqual(lexical_units[0].wordform, 'My')
+        self.assertEqual(lexical_units[0].wordbound_blank, '[[t:b:123456]]')
+        self.assertEqual(lexical_units[1].wordform, 'test')
+        self.assertEqual(lexical_units[1].wordbound_blank, '')
+        self.assertEqual(lexical_units[2].wordform, 'name')
+        self.assertEqual(lexical_units[2].wordbound_blank, '[[t:i:12asda; t:p:1abc76]]')
+
     def test_blanks_with_wordbound_blanks(self):
         lexical_units_with_blanks = list(parse(self.s5, with_text=True))
         self.assertEqual(len(lexical_units_with_blanks), 3)

--- a/test.py
+++ b/test.py
@@ -20,6 +20,7 @@ class Test(unittest.TestCase):
     s2 = '^hypercholesterolemia/*hypercholesterolemia$'
     s3 = '$^vino/vino<n><m><sg>/venir<vblex><ifi><p3><sg>$'
     s4 = '^dímelo/decir<vblex><imp><p2><sg>+me<prn><enc><p1><mf><sg>+lo<prn><enc><p3><nt>/decir<vblex><imp><p2><sg>+me<prn><enc><p1><mf><sg>+lo<prn><enc><p3><m><sg>$'
+    s5 = '[] [[t:b:123456]]^My/My<det><pos><sp>$ ^test/testlem<tags1><tags2>$ [\[] [\]blank] [[t:i:12asda; t:p:1abc76]]^name/name<n><sg>/name<vblex><inf>/name<vblex><pres>$'
 
     def test_parse(self):
         lexical_units = list(parse(self.s1))
@@ -106,6 +107,34 @@ class Test(unittest.TestCase):
             self.assertEqual(len(caught_warnings), 1)
             self.assertTrue(issubclass(caught_warnings[0].category, RuntimeWarning))
             self.assertIn('Empty readings', str(caught_warnings[0].message))
+            
+    def test_wordbound_blanks(self):
+        lexical_units = list(parse(self.s5))
+        self.assertEqual(len(lexical_units), 3)
+        self.assertListEqual(
+            lexical_units[2].readings,
+            [
+                [SReading(baseform='name', tags=['n', 'sg'])],
+                [SReading(baseform='name', tags=['vblex', 'inf'])],
+                [SReading(baseform='name', tags=['vblex', 'pres'])]
+            ]
+        )
+        self.assertEqual(lexical_units[0].wordform, "My")
+        self.assertEqual(lexical_units[0].wordbound_blank, "[[t:b:123456]]")
+        self.assertEqual(lexical_units[1].wordform, "test")
+        self.assertEqual(lexical_units[1].wordbound_blank, "")
+        self.assertEqual(lexical_units[2].wordform, "name")
+        self.assertEqual(lexical_units[2].wordbound_blank, "[[t:i:12asda; t:p:1abc76]]")
+        
+    def test_blanks_with_wordbound_blanks(self):
+        lexical_units_with_blanks = list(parse(self.s5, with_text=True))
+        self.assertEqual(len(lexical_units_with_blanks), 3)
+        blank, _lexical_unit = lexical_units_with_blanks[0]
+        self.assertEqual(blank, r'[] ')
+        blank, _lexical_unit = lexical_units_with_blanks[1]
+        self.assertEqual(blank, r' ')
+        blank, _lexical_unit = lexical_units_with_blanks[2]
+        self.assertEqual(blank, r' [\[] [\]blank] ')
 
 
 if __name__ == '__main__':

--- a/test.py
+++ b/test.py
@@ -20,7 +20,7 @@ class Test(unittest.TestCase):
     s2 = '^hypercholesterolemia/*hypercholesterolemia$'
     s3 = '$^vino/vino<n><m><sg>/venir<vblex><ifi><p3><sg>$'
     s4 = '^dímelo/decir<vblex><imp><p2><sg>+me<prn><enc><p1><mf><sg>+lo<prn><enc><p3><nt>/decir<vblex><imp><p2><sg>+me<prn><enc><p1><mf><sg>+lo<prn><enc><p3><m><sg>$'
-    s5 = '[] [[t:b:123456]]^My/My<det><pos><sp>$ ^test/testlem<tags1><tags2>$ [\[] [\]blank] [[t:i:12asda; t:p:1abc76]]^name/name<n><sg>/name<vblex><inf>/name<vblex><pres>$'
+    s5 = r'[] [[t:b:123456]]^My/My<det><pos><sp>$ ^test/testlem<tags1><tags2>$ [\[] [\]blank] [[t:i:12asda; t:p:1abc76]]^name/name<n><sg>/name<vblex><inf>/name<vblex><pres>$'
 
     def test_parse(self):
         lexical_units = list(parse(self.s1))

--- a/test.py
+++ b/test.py
@@ -20,7 +20,7 @@ class Test(unittest.TestCase):
     s2 = '^hypercholesterolemia/*hypercholesterolemia$'
     s3 = '$^vino/vino<n><m><sg>/venir<vblex><ifi><p3><sg>$'
     s4 = '^dímelo/decir<vblex><imp><p2><sg>+me<prn><enc><p1><mf><sg>+lo<prn><enc><p3><nt>/decir<vblex><imp><p2><sg>+me<prn><enc><p1><mf><sg>+lo<prn><enc><p3><m><sg>$'
-    s5 = r'[] [[t:b:123456]]^My/My<det><pos><sp>$ ^test/testlem<tags1><tags2>$ [\[] [\]blank] [[t:i:12asda; t:p:1abc76]]^name/name<n><sg>/name<vblex><inf>/name<vblex><pres>$'
+    s5 = r'[] [[t:b:123456]]^My/My<det><pos><sp>$ [bl] ^test/testlem<tags1><tags2>$ [\[] [\]blank] [[t:i:12asda; t:p:1abc76]]^name/name<n><sg>/name<vblex><inf>/name<vblex><pres>$'
 
     def test_parse(self):
         lexical_units = list(parse(self.s1))
@@ -132,7 +132,7 @@ class Test(unittest.TestCase):
         blank, _lexical_unit = lexical_units_with_blanks[0]
         self.assertEqual(blank, r'[] ')
         blank, _lexical_unit = lexical_units_with_blanks[1]
-        self.assertEqual(blank, r' ')
+        self.assertEqual(blank, r' [bl] ')
         blank, _lexical_unit = lexical_units_with_blanks[2]
         self.assertEqual(blank, r' [\[] [\]blank] ')
 

--- a/test.py
+++ b/test.py
@@ -122,7 +122,7 @@ class Test(unittest.TestCase):
         self.assertEqual(lexical_units[0].wordform, 'My')
         self.assertEqual(lexical_units[0].wordbound_blank, '[[t:b:123456]]')
         self.assertEqual(lexical_units[1].wordform, 'test')
-        self.assertEqual(lexical_units[1].wordbound_blank, None)
+        self.assertEqual(lexical_units[1].wordbound_blank, '')
         self.assertEqual(lexical_units[2].wordform, 'name')
         self.assertEqual(lexical_units[2].wordbound_blank, '[[t:i:12asda; t:p:1abc76]]')
 

--- a/test.py
+++ b/test.py
@@ -122,7 +122,7 @@ class Test(unittest.TestCase):
         self.assertEqual(lexical_units[0].wordform, 'My')
         self.assertEqual(lexical_units[0].wordbound_blank, '[[t:b:123456]]')
         self.assertEqual(lexical_units[1].wordform, 'test')
-        self.assertEqual(lexical_units[1].wordbound_blank, '')
+        self.assertEqual(lexical_units[1].wordbound_blank, None)
         self.assertEqual(lexical_units[2].wordform, 'name')
         self.assertEqual(lexical_units[2].wordbound_blank, '[[t:i:12asda; t:p:1abc76]]')
 


### PR DESCRIPTION
- New attribute in the Lexical Unit class:
```wordbound_blank (str): The wordbound blank of the lexical unit.```
- Wordbound blanks are parsed as part of the lexical unit. So if input: ``[[t:b:123456]]^My/My<det><pos><sp>$``, then the string member ``LexicalUnit.lexical_unit`` will be: ``[[t:b:123456]]^My/My<det><pos><sp>``, as opposed to the usual ``My/My<det><pos><sp>``.
- ``LexicalUnit.word_form`` contains only the surface form ``My``, and ``LexicalUnit.wordbound_blank`` contains ``[[t:b:123456]]``.
- Tests added.
- Closes #36 