### PR TITLE
Added Power Support ppc64le

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,4 +1,7 @@
 language: python
+arch:
+    - amd64
+    - ppc64le
 cache: pip
 python:
     - '3.4'
@@ -16,6 +19,12 @@ after_success:
 matrix:
     allow_failures:
         - python: nightly
+# Disable Version pypy3,nightly for power support          
+    exclude:
+        - arch: ppc64le
+          python: pypy3
+        - arch: ppc64le
+          python: nightly
 notifications:
     irc:
         channels:


### PR DESCRIPTION
Hi, have added power support ppc64le to the travis.yml, this patch would allow us to do regression testing on ppc64le using the free travis infrastructure. ansi is part of debian and Ubuntu ppc64le distributions and this helps ensure that the source tree does not regress wrt ppc64le support. I have disabled pypy3 python version for power support as it is not supported. Even nightly is disabled as it is a allowed failure in the amd64 itself. Thanks!